### PR TITLE
Add Copy support, clean up temp files on close

### DIFF
--- a/src/ToolWindow/AssemblyLoadDebuggerControl.xaml
+++ b/src/ToolWindow/AssemblyLoadDebuggerControl.xaml
@@ -21,7 +21,7 @@
         <ToggleButton HorizontalAlignment="Left" Margin="4"
                       Command="{Binding Path=ToggleCaptureCommand, Mode=OneTime}" 
                       IsChecked="{Binding Path=IsCapturing, Mode=OneWay}"
-                      Content="Capture"/>
+                      Content="{Binding Path=CaptureButtonText, Mode=OneWay}"/>
         <Grid Grid.Row="1" Margin="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto" />
@@ -42,8 +42,12 @@
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
-        <Button Grid.Row="3" HorizontalAlignment="Left" Margin="4"
-                Command="{Binding Path=ClearEntriesCommand, Mode=OneWay}">Clear</Button>
+        <StackPanel  Grid.Row="3" Orientation="Horizontal">
+            <Button HorizontalAlignment="Left" Margin="4"
+                    Command="{Binding Path=ClearEntriesCommand, Mode=OneWay}">Clear</Button>
+            <Button HorizontalAlignment="Left" Margin="4"
+                    Command="{Binding Path=CopyEntriesCommand, Mode=OneWay}">Copy</Button>
+        </StackPanel>
         <Label Grid.Row="4">Break conditions (regular expressions)</Label>
         <ListBox Grid.Row="5" ItemsSource="{Binding Path=BreakOn, Mode=OneWay}" SelectedItem="{Binding Path=SelectedBreakCondition, Mode=TwoWay}" />
         <Grid Grid.Row="6" Margin="4">

--- a/src/ToolWindow/AssemblyLoadDebuggerToolWindow.cs
+++ b/src/ToolWindow/AssemblyLoadDebuggerToolWindow.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Runtime.InteropServices;
+    using System.Windows.Controls;
     using Microsoft.VisualStudio.Shell;
 
     [Guid("71604717-b15d-4d1e-9fb4-03f5122e8858")]
@@ -14,6 +15,12 @@
             AssemblyLoadDebuggerControl control = new AssemblyLoadDebuggerControl();
             control.DataContext = AssemblyLoadDebuggerControlViewModel.Instance;
             this.Content = control;
+        }
+
+        protected override void OnClose()
+        {
+            AssemblyLoadDebuggerControlViewModel.Instance?.Close();
+            base.OnClose();
         }
     }
 }


### PR DESCRIPTION
Added a new Copy button which copies the call stack information for each item to the clipboard. 
Found it difficult to know when capture was in progress so changed the text when the button changes state
Deletes the temporary files containing the call stacks on close.
