### PR TITLE
Save settings, add start capture on load

### DIFF
--- a/src/AssemblyLoadDebugger.csproj
+++ b/src/AssemblyLoadDebugger.csproj
@@ -53,6 +53,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ToolWindow\Settings.cs" />
     <Compile Include="VSCommandTable.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -80,7 +81,9 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
       <Generator>VsixManifestGenerator</Generator>
@@ -207,6 +210,9 @@
     <Reference Include="Microsoft.VisualStudio.Validation, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.0.11-pre\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/ToolWindow/AssemblyLoadDebuggerControl.xaml
+++ b/src/ToolWindow/AssemblyLoadDebuggerControl.xaml
@@ -18,10 +18,15 @@
             <RowDefinition />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
-        <ToggleButton HorizontalAlignment="Left" Margin="4"
+        <StackPanel  Grid.Row="0" Orientation="Horizontal">
+            <ToggleButton HorizontalAlignment="Left" Margin="4"
                       Command="{Binding Path=ToggleCaptureCommand, Mode=OneTime}" 
                       IsChecked="{Binding Path=IsCapturing, Mode=OneWay}"
                       Content="{Binding Path=CaptureButtonText, Mode=OneWay}"/>
+            <CheckBox HorizontalAlignment="Left" Margin="6,4,4,4" VerticalAlignment="Center" 
+                      IsChecked="{Binding Path=IsAutoCapturing, Mode=TwoWay}"
+                      Content="Start capture when loaded"/>
+        </StackPanel>
         <Grid Grid.Row="1" Margin="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto" />
@@ -55,6 +60,7 @@
                 <ColumnDefinition />
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>
             <TextBox Grid.Column="0" Text="{Binding Path=UserEntryBreakCondition, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <Button Grid.Column="1" 
@@ -64,6 +70,8 @@
             <Button Grid.Column="2"
                 Command="{Binding Path=RemoveBreakConditionCommand, Mode=OneWay}"
                 CommandParameter="{Binding Path=SelectedBreakCondition, Mode=OneWay}">Remove</Button>
+            <Button Grid.Column="3"
+                Command="{Binding Path=ClearAllBreakpointsCommand, Mode=OneWay}">Clear</Button>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/ToolWindow/AssemblyLoadDebuggerToolWindow.cs
+++ b/src/ToolWindow/AssemblyLoadDebuggerToolWindow.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Runtime.InteropServices;
-    using System.Windows.Controls;
     using Microsoft.VisualStudio.Shell;
 
     [Guid("71604717-b15d-4d1e-9fb4-03f5122e8858")]

--- a/src/ToolWindow/Settings.cs
+++ b/src/ToolWindow/Settings.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AssemblyLoadDebugger
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class Settings
+    {
+        [JsonProperty("autoCapture")]
+        public bool AutoCapture { get; set; }
+
+        [JsonProperty("breakPoints")]
+        public List<string> BreakPoints{ get; set; }
+
+        public static Settings FromFile(string settingsFilePath)
+        {
+            if (File.Exists(settingsFilePath))
+            {
+                try
+                {
+                    string jsonString = File.ReadAllText(settingsFilePath);
+                    return JObject.Parse(jsonString).ToObject<Settings>();
+                }
+                catch
+                {
+                }
+            }
+
+            return new Settings()
+            {
+                BreakPoints = new List<string>()
+            };
+        }
+
+        public void SaveSettings(string settingsFilePath)
+        {
+            try
+            {
+                string jsonString = JsonConvert.SerializeObject(this, Formatting.Indented, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
+                File.WriteAllText(settingsFilePath, jsonString);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/src/app.config
+++ b/src/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="Microsoft.VisualStudio.ImageCatalog" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/packages.config
+++ b/src/packages.config
@@ -21,4 +21,5 @@
   <package id="Microsoft.VisualStudio.Utilities" version="15.0.26109-RC3" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Validation" version="15.0.11-pre" targetFramework="net46" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26109-RC3" targetFramework="net46" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Added "Start capture on load" option
Added support for saving breakpoints and the above option to a settings file (under VS app data)
Fixed Copy to only copy the set of filtered items
