### PR TITLE
Add back code to break on assembly load

### DIFF
--- a/src/ToolWindow/AssemblyLoadDebuggerControlViewModel.cs
+++ b/src/ToolWindow/AssemblyLoadDebuggerControlViewModel.cs
@@ -259,27 +259,7 @@ namespace AssemblyLoadDebugger
 
         private Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
         {
-            if (BreakOn.Any(x =>
-            {
-                try
-                {
-                    return Regex.IsMatch(args.Name, x, RegexOptions.IgnoreCase);
-                }
-                catch
-                {
-                    return false;
-                }
-            }))
-            {
-                if (Debugger.IsAttached)
-                {
-                    Debugger.Break();
-                }
-                else
-                {
-                    Debugger.Launch();
-                }
-            }
+            BreakIfAssemblyMatches(args.Name);
 
             string s = _applicationInfo;
             s += $"Managed thread ID: {Thread.CurrentThread.ManagedThreadId}{Environment.NewLine}";
@@ -301,6 +281,8 @@ namespace AssemblyLoadDebugger
         [DebuggerStepThrough]
         private void OnAssemblyLoaded(object sender, AssemblyLoadEventArgs args)
         {
+            BreakIfAssemblyMatches(args.LoadedAssembly.FullName);
+
             AssemblyName name = args.LoadedAssembly.GetName();
             string s = _applicationInfo;
             s += $"Managed thread ID: {Thread.CurrentThread.ManagedThreadId}{Environment.NewLine}";
@@ -332,6 +314,31 @@ namespace AssemblyLoadDebugger
             using (StreamWriter w = new StreamWriter(str, Encoding.UTF8, 8192, true))
             {
                 w.WriteLine(s);
+            }
+        }
+
+        private void BreakIfAssemblyMatches(string assemblyName)
+        {
+            if (BreakOn.Any(x =>
+            {
+                try
+                {
+                    return Regex.IsMatch(assemblyName, x, RegexOptions.IgnoreCase);
+                }
+                catch
+                {
+                    return false;
+                }
+            }))
+            {
+                if (Debugger.IsAttached)
+                {
+                    Debugger.Break();
+                }
+                else
+                {
+                    Debugger.Launch();
+                }
             }
         }
 

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="34f00824-cb6a-4bc1-a27d-7375239cdd2f" Version="1.1" Language="en-US" Publisher="Mike Lorbetske" />
-    <DisplayName>Assembly Load Debugger</DisplayName>
-    <Description xml:space="preserve">Shows what assemblies Visual Studio loads and what component caused it to load</Description>
-    <MoreInfo>https://github.com/mlorbetske/VSAssemblyLoadDebugger/</MoreInfo>
-    <License>Resources\LICENSE</License>
-    <ReleaseNotes>https://github.com/mlorbetske/VSAssemblyLoadDebugger/blob/master/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\Icon.png</Icon>
-    <PreviewImage>Resources\Icon.png</PreviewImage>
-    <Tags>assembly, performance, assemblies</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="34f00824-cb6a-4bc1-a27d-7375239cdd2f" Version="1.2" Language="en-US" Publisher="Mike Lorbetske" />
+        <DisplayName>Assembly Load Debugger</DisplayName>
+        <Description xml:space="preserve">Shows what assemblies Visual Studio loads and what component caused it to load</Description>
+        <MoreInfo>https://github.com/mlorbetske/VSAssemblyLoadDebugger/</MoreInfo>
+        <License>Resources\LICENSE</License>
+        <ReleaseNotes>https://github.com/mlorbetske/VSAssemblyLoadDebugger/blob/master/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\Icon.png</Icon>
+        <PreviewImage>Resources\Icon.png</PreviewImage>
+        <Tags>assembly, performance, assemblies</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
This change https://github.com/mlorbetske/VSAssemblyLoadDebugger/pull/5 inadvertently broke the feature to beak into the debugger when an assembly loads. Adding it back with a little refactoring so the code is shared between both resolve handlers.